### PR TITLE
Solve cache problems

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.0.10
 
 [bumpversion:file:blender_downloader/__init__.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = blender_downloader
-version = 0.0.9
+version = 0.0.10
 description = Multiplatorm Blender downloader.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Closes #25

- Cache now is restored for each new version of `blender-downloader`.
- Add `--no-cache/--nocache` option to disable cache in that execution.
- Add `--invalidate-cache/--clear-cache` to clear all blender-downloader's cache stored in the last 3 days.