### PR TITLE
Complete support for Python3.6 on MacOS

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.14
+current_version = 0.0.15
 
 [bumpversion:file:blender_downloader/__init__.py]
 

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -22,7 +22,7 @@ from tqdm import tqdm
 __author__ = "mondeja"
 __description__ = "Multiplatorm Blender portable release downloader script."
 __title__ = "blender-downloader"
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 
 QUIET = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = blender_downloader
-version = 0.0.14
+version = 0.0.15
 description = Multiplatorm Blender downloader.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -27,7 +27,7 @@ install_requires =
     appdirs
     diskcache
     tqdm
-    dmglib;sys.platform == "darwin"
+    dmglib>=0.9.3;sys.platform == "darwin"
 python_requires = >=3.6
 
 [options.entry_points]


### PR DESCRIPTION
Minimum required version of `dmglib` is now 0.9.3.