### PR TITLE
Unify new and old Blender releases version numbers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.16
+current_version = 0.0.17
 
 [bumpversion:file:blender_downloader/__init__.py]
 

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -22,7 +22,7 @@ from tqdm import tqdm
 __author__ = "mondeja"
 __description__ = "Multiplatorm Blender portable release downloader script."
 __title__ = "blender-downloader"
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 
 QUIET = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = blender_downloader
-version = 0.0.16
+version = 0.0.17
 description = Multiplatorm Blender downloader.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Blender versions starting at `2.83` must be defined as `2.83.0`, with the leading zero.

Fixes #33