### PR TITLE
Implement stable discovering of releases by identifier

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.17
+current_version = 0.0.18
 
 [bumpversion:file:blender_downloader/__init__.py]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/__pycache__
+__pycache__
 /venv
 blender-*
 !blender_downloader.py

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -22,7 +22,7 @@ from tqdm import tqdm
 __author__ = "mondeja"
 __description__ = "Multiplatform Blender portable release downloader script."
 __title__ = "blender-downloader"
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 
 QUIET = False
 

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -198,7 +198,7 @@ def parse_args(args):
     # operative system by function and assert that is valid
     if hasattr(opts.operative_system, "__call__"):
         opts.operative_system = opts.operative_system()
-    if opts.operative_system not in ["linux", "macos", "windows"]:
+    if opts.operative_system not in {"linux", "macos", "windows"}:
         sys.stderr.write(
             f"Invalid operative system '{opts.operative_system}'. Must be"
             " either 'linux', 'macos' or 'windows'.\n"
@@ -217,7 +217,7 @@ def parse_args(args):
             parser.print_help()
             sys.exit(1)
 
-        if opts.blender_version in ["stable", "lts", "nightly"]:
+        if opts.blender_version in {"stable", "lts", "nightly"}:
             opts.blender_version = discover_version_number_by_identifier(
                 opts.blender_version,
                 use_cache=opts.use_cache,

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -76,8 +76,8 @@ def build_parser():
         metavar="BLENDER_VERSION",
         help="Blender version to download. Could be a version number"
         " or one of the words 'stable' (current stable version), 'lts'"
-        " (latest long term support version) and 'nightly' (latest"
-        " development release)."
+        " (latest long term support version) and 'nightly' or 'daily'"
+        " (latest development release)."
         f" The minimum version supported is {MINIMUM_VERSION_SUPPPORTED}.",
     )
     parser.add_argument(
@@ -217,7 +217,7 @@ def parse_args(args):
             parser.print_help()
             sys.exit(1)
 
-        if opts.blender_version in {"stable", "lts", "nightly"}:
+        if opts.blender_version in {"stable", "lts", "nightly", "daily"}:
             opts.blender_version = discover_version_number_by_identifier(
                 opts.blender_version,
                 use_cache=opts.use_cache,
@@ -298,7 +298,7 @@ def discover_version_number_by_identifier(identifier, use_cache=True):
                 " {SCRIPT_NEW_ISSUE_URL}.\n"
             )
             sys.exit(1)
-    elif identifier in ["lts", "nightly"]:
+    elif identifier in {"lts", "nightly", "daily"}:
         expected_substr_in_data = "lts" if identifier == "lts" else "dev"
         latest_Version = None
 

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -220,6 +220,8 @@ def parse_args(args):
         if opts.blender_version is None:
             parser.print_help()
             sys.exit(1)
+        else:
+            opts.blender_version = opts.blender_version.lower()
 
         if opts.blender_version in {"stable", "lts", "nightly", "daily"}:
             opts.blender_version = discover_version_number_by_identifier(

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -202,6 +202,7 @@ def parse_args(args):
     # operative system by function and assert that is valid
     if hasattr(opts.operative_system, "__call__"):
         opts.operative_system = opts.operative_system()
+    opts.operative_system = opts.operative_system.lower()
     if opts.operative_system not in {"linux", "macos", "windows"}:
         sys.stderr.write(
             f"Invalid operative system '{opts.operative_system}'. Must be"

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -10,7 +10,6 @@ import re
 import shutil
 import sys
 import tarfile
-from unicodedata import normalize
 import zipfile
 from urllib.request import Request, urlopen, urlsplit
 
@@ -316,6 +315,7 @@ def discover_version_number_by_identifier(identifier, use_cache=True):
         )
         sys.exit(1)
     return normalize_version(str(latest_Version))
+
 
 def _build_download_repo_expected_os_identifier(
     operative_system,
@@ -809,7 +809,8 @@ def list_available_blender_versions(
 
     # Nightly version number
     nightly_version = discover_version_number_by_identifier(
-        "nightly", use_cache=use_cache,
+        "nightly",
+        use_cache=use_cache,
     )
     sys.stdout.write(f"{nightly_version}\n")
     versions_found.append(nightly_version)
@@ -819,7 +820,8 @@ def list_available_blender_versions(
 
     # Stable version number
     stable_version = discover_version_number_by_identifier(
-        "stable", use_cache=use_cache,
+        "stable",
+        use_cache=use_cache,
     )
     sys.stdout.write(f"{stable_version}\n")
     versions_found.append(stable_version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = blender_downloader
-version = 0.0.17
+version = 0.0.18
 description = Multiplatorm Blender downloader.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_discover_version_number_by_identifier.py
+++ b/tests/test_discover_version_number_by_identifier.py
@@ -7,22 +7,27 @@ from pkg_resources.extern.packaging.version import Version
 
 from blender_downloader import discover_version_number_by_identifier
 
-NUMBER_VERSION_REGEX = re.compile(r'\d+\.\d+\.\d+')
+
+NUMBER_VERSION_REGEX = re.compile(r"\d+\.\d+\.\d+")
 
 
 def test_discover_version_number_by_identifier():
-    lts_version = discover_version_number_by_identifier('lts')
+    lts_version = discover_version_number_by_identifier("lts")
     sys.stdout.write("\n")
     sys.stdout.write(f"LTS release: {lts_version}\n")
     assert re.match(NUMBER_VERSION_REGEX, lts_version)
 
-    stable_version = discover_version_number_by_identifier('stable')
+    stable_version = discover_version_number_by_identifier("stable")
     sys.stdout.write(f"Stable release: {stable_version}\n")
     assert re.match(NUMBER_VERSION_REGEX, stable_version)
     assert Version(stable_version) >= Version(lts_version)
 
     nightly_version = discover_version_number_by_identifier("nightly")
-    sys.stdout.write(f"Nightly release: {nightly_version}\n")
+    sys.stdout.write(f"Nightly/daily release: {nightly_version}\n")
     assert re.match(NUMBER_VERSION_REGEX, nightly_version)
     assert Version(nightly_version) > Version(lts_version)
     assert Version(nightly_version) > Version(stable_version)
+
+    daily_version = discover_version_number_by_identifier("daily")
+    assert re.match(NUMBER_VERSION_REGEX, nightly_version)
+    assert Version(nightly_version) == Version(daily_version)

--- a/tests/test_discover_version_number_by_identifier.py
+++ b/tests/test_discover_version_number_by_identifier.py
@@ -1,0 +1,28 @@
+"""Test that the stable version number can be retrieved from Blender website."""
+
+import re
+import sys
+
+from pkg_resources.extern.packaging.version import Version
+
+from blender_downloader import discover_version_number_by_identifier
+
+NUMBER_VERSION_REGEX = re.compile(r'\d+\.\d+\.\d+')
+
+
+def test_discover_version_number_by_identifier():
+    lts_version = discover_version_number_by_identifier('lts')
+    sys.stdout.write("\n")
+    sys.stdout.write(f"LTS release: {lts_version}\n")
+    assert re.match(NUMBER_VERSION_REGEX, lts_version)
+
+    stable_version = discover_version_number_by_identifier('stable')
+    sys.stdout.write(f"Stable release: {stable_version}\n")
+    assert re.match(NUMBER_VERSION_REGEX, stable_version)
+    assert Version(stable_version) >= Version(lts_version)
+
+    nightly_version = discover_version_number_by_identifier("nightly")
+    sys.stdout.write(f"Nightly release: {nightly_version}\n")
+    assert re.match(NUMBER_VERSION_REGEX, nightly_version)
+    assert Version(nightly_version) > Version(lts_version)
+    assert Version(nightly_version) > Version(stable_version)

--- a/tests/test_get_legacy_release_download_url.py
+++ b/tests/test_get_legacy_release_download_url.py
@@ -21,6 +21,7 @@ from blender_downloader import (
 @pytest.mark.parametrize(
     "blender_version",
     (
+        "3.0.0",
         "2.93.1",
         "2.93.0",  # change in release formats
         "2.92.0",
@@ -149,7 +150,7 @@ def test_get_legacy_release_download_url(blender_version, operative_system, bits
                 assert_url("{blender_version}-OSX_10.6-x86_64.zip")
         elif blender_Version < Version("2.79"):
             assert_url("{blender_version}-OSX_10.6-x86_64.zip")
-        else:  # blender_Version < Version("2.71"):
+        else:  # Version("2.71") < blender_Version < Version("2.79")
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.6-i386.zip")
             else:
@@ -165,10 +166,10 @@ def test_get_legacy_release_download_url(blender_version, operative_system, bits
             assert_url("{blender_version}-windows64.zip")
         elif blender_Version > Version("2.65"):
             assert_url("{blender_version}-windows{bits}.zip")
-        elif blender_Version < Version("2.61"):
-            assert_url("{blender_version}-windows{bits}.zip")
-        else:
+        elif blender_Version > Version("2.60"):
             assert_url("{blender_version}-release-windows{bits}.zip")
+        else: # blender_Version < Version("2.61")
+            assert_url("{blender_version}-windows{bits}.zip")
     else:  # operative_system == "linux":
         if blender_Version >= Version("2.93"):
             assert_url("{blender_version}-linux-x64.tar.xz")
@@ -195,7 +196,7 @@ def test_get_legacy_release_download_url(blender_version, operative_system, bits
                 assert_url("{blender_version}-linux-glibc27-i686.tar.bz2")
             else:
                 assert_url("{blender_version}-linux-glibc27-x86_64.tar.bz2")
-        else:
+        else:  # Version("2.64") < blender_Version < Version("2.79")
             if bits == 32:
                 assert_url("{blender_version}-linux-glibc211-i686.tar.bz2")
             else:

--- a/tests/test_get_legacy_release_download_url.py
+++ b/tests/test_get_legacy_release_download_url.py
@@ -168,7 +168,7 @@ def test_get_legacy_release_download_url(blender_version, operative_system, bits
             assert_url("{blender_version}-windows{bits}.zip")
         elif blender_Version > Version("2.60"):
             assert_url("{blender_version}-release-windows{bits}.zip")
-        else: # blender_Version < Version("2.61")
+        else:  # blender_Version < Version("2.61")
             assert_url("{blender_version}-windows{bits}.zip")
     else:  # operative_system == "linux":
         if blender_Version >= Version("2.93"):

--- a/tests/test_get_nightly_release_download_url.py
+++ b/tests/test_get_nightly_release_download_url.py
@@ -1,0 +1,27 @@
+import pytest
+
+from blender_downloader import (
+    BlenderVersionNotFound,
+    discover_version_number_by_identifier,
+    get_nightly_release_download_url,
+)
+
+
+@pytest.mark.parametrize("operative_system", ("linux", "macos", "windows"))
+@pytest.mark.parametrize("arch", ("arm64", None))
+def test_get_nightly_release_download_url(operative_system, arch):
+    blender_version = discover_version_number_by_identifier("nightly")
+
+    def get_url():
+        return get_nightly_release_download_url(
+            blender_version,
+            operative_system,
+            arch,
+        )
+
+    if arch == "arm64" and operative_system != "macos":
+        with pytest.raises(BlenderVersionNotFound):
+            get_url()
+    else:
+        url = get_url()
+        assert f"/blender-{blender_version}-" in url

--- a/tests/test_get_nightly_release_download_url.py
+++ b/tests/test_get_nightly_release_download_url.py
@@ -25,3 +25,5 @@ def test_get_nightly_release_download_url(operative_system, arch):
     else:
         url = get_url()
         assert f"/blender-{blender_version}-" in url
+        assert url.startswith("https://")
+        assert "." in url

--- a/tests/test_get_stable_release_version_number.py
+++ b/tests/test_get_stable_release_version_number.py
@@ -1,9 +1,0 @@
-"""Test that the stable version number can be retrieved from Blender website."""
-
-import re
-
-from blender_downloader import get_stable_release_version_number
-
-
-def test_get_stable_release_version_number():
-    assert re.match(r"^\d+\.\d+\.\d+", get_stable_release_version_number())

--- a/tests/test_list_available_blender_versions.py
+++ b/tests/test_list_available_blender_versions.py
@@ -19,7 +19,7 @@ class BlenderVersion:
     def __init__(self, raw):
         self.raw = raw
 
-        self.version_info = list()
+        self.version_info = []
         for i, partial in enumerate(raw.split(".")):
             if i > 1:
                 for ch in partial:
@@ -41,10 +41,10 @@ class BlenderVersion:
         return self.raw
 
 
-@pytest.mark.parametrize("arch", (None, "arm64"))
 @pytest.mark.parametrize("maximum_versions", (1, 2, random.randint(5, 10), math.inf))
 @pytest.mark.parametrize("operative_system", ("linux", "windows", "macos"))
 @pytest.mark.parametrize("bits", (64, 32))
+@pytest.mark.parametrize("arch", (None, "arm64"))
 def test_list_available_blender_versions(
     maximum_versions, operative_system, bits, arch
 ):


### PR DESCRIPTION
Closes #22 and closes #41.

- Implements `'stable'`, `'lts'` and `'nightly'`/`'daily'` acceptance as Blender version argument. The version numbers are discovered using an endpoint obtained from the manual.
- Download nightly releases from Blender's builder website endpoints.