### PR TITLE
Fix error ordering versions with '-l' option

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.20
+current_version = 0.0.21
 
 [bumpversion:file:blender_downloader/__init__.py]
 

--- a/blender_downloader/__init__.py
+++ b/blender_downloader/__init__.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 __author__ = "mondeja"
 __description__ = "Multiplatform Blender portable release downloader script."
 __title__ = "blender-downloader"
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 
 QUIET = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = blender_downloader
-version = 0.0.20
+version = 0.0.21
 description = Multiplatorm Blender downloader.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_discover_version_number_by_identifier.py
+++ b/tests/test_discover_version_number_by_identifier.py
@@ -3,9 +3,7 @@
 import re
 import sys
 
-from pkg_resources.extern.packaging.version import Version
-
-from blender_downloader import discover_version_number_by_identifier
+from blender_downloader import BlenderVersion, discover_version_number_by_identifier
 
 
 NUMBER_VERSION_REGEX = re.compile(r"\d+\.\d+\.\d+")
@@ -20,14 +18,14 @@ def test_discover_version_number_by_identifier():
     stable_version = discover_version_number_by_identifier("stable")
     sys.stdout.write(f"Stable release: {stable_version}\n")
     assert re.match(NUMBER_VERSION_REGEX, stable_version)
-    assert Version(stable_version) >= Version(lts_version)
+    assert BlenderVersion(stable_version) >= BlenderVersion(lts_version)
 
     nightly_version = discover_version_number_by_identifier("nightly")
     sys.stdout.write(f"Nightly/daily release: {nightly_version}\n")
     assert re.match(NUMBER_VERSION_REGEX, nightly_version)
-    assert Version(nightly_version) > Version(lts_version)
-    assert Version(nightly_version) > Version(stable_version)
+    assert BlenderVersion(nightly_version) > BlenderVersion(lts_version)
+    assert BlenderVersion(nightly_version) > BlenderVersion(stable_version)
 
     daily_version = discover_version_number_by_identifier("daily")
     assert re.match(NUMBER_VERSION_REGEX, nightly_version)
-    assert Version(nightly_version) == Version(daily_version)
+    assert BlenderVersion(nightly_version) == BlenderVersion(daily_version)

--- a/tests/test_get_legacy_release_download_url.py
+++ b/tests/test_get_legacy_release_download_url.py
@@ -8,12 +8,11 @@ import re
 from urllib.request import urlsplit
 
 import pytest
-from pkg_resources import parse_version
-from pkg_resources.extern.packaging.version import Version
 
 from blender_downloader import (
     MINIMUM_VERSION_SUPPPORTED,
     SUPPORTED_FILETYPES_EXTRACTION,
+    BlenderVersion,
     get_legacy_release_download_url,
 )
 
@@ -63,9 +62,9 @@ from blender_downloader import (
 @pytest.mark.parametrize("bits", (32, 64))
 @pytest.mark.parametrize("arch", (None, "arm64", "i686"))
 def test_get_legacy_release_download_url(blender_version, operative_system, bits, arch):
-    blender_Version = parse_version(blender_version)
+    blender_Version = BlenderVersion(blender_version)
 
-    if blender_Version < Version(MINIMUM_VERSION_SUPPPORTED):
+    if blender_Version < BlenderVersion(MINIMUM_VERSION_SUPPPORTED):
         mocked_stderr = io.StringIO()
         with pytest.raises(SystemExit):
             with contextlib.redirect_stderr(mocked_stderr):
@@ -104,99 +103,99 @@ def test_get_legacy_release_download_url(blender_version, operative_system, bits
         )
 
     if operative_system == "macos":
-        if blender_Version >= Version("2.93"):
+        if blender_Version >= BlenderVersion("2.93"):
             if arch in ["x64", "arm64"]:
                 assert_url(f"{blender_version}-macos-{arch}.dmg")
             else:
                 assert_url("{blender_version}-macos-x64.dmg")
-        elif blender_Version >= Version("2.83.14") and blender_Version < Version(
-            "2.84"
-        ):
+        elif blender_Version >= BlenderVersion(
+            "2.83.14"
+        ) and blender_Version < BlenderVersion("2.84"):
             assert_url("{blender_version}-macos-x64.dmg")
-        elif blender_Version > Version("2.79"):
+        elif blender_Version > BlenderVersion("2.79"):
             assert_url("{blender_version}-macOS.dmg")
-        elif blender_Version == Version("2.79"):
+        elif blender_Version == BlenderVersion("2.79"):
             assert_url("{blender_version}-macOS-10.6.tar.gz")
-        elif blender_Version == Version("2.71"):
+        elif blender_Version == BlenderVersion("2.71"):
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.6-j2k-fix-i386.zip")
             else:
                 assert_url("{blender_version}-OSX_10.6-j2k-fix-x86_64.zip")
-        elif blender_Version < Version("2.60"):
+        elif blender_Version < BlenderVersion("2.60"):
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.5_i386.zip")
             else:
                 assert_url("{blender_version}-OSX_10.5_x86_64.zip")
-        elif blender_Version == Version("2.60"):
+        elif blender_Version == BlenderVersion("2.60"):
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.5_i386.zip")
             else:
                 assert_url("{blender_version}-OSX_10.6_x86_64.zip")
-        elif blender_Version < Version("2.64"):
+        elif blender_Version < BlenderVersion("2.64"):
             if bits == 32:
                 assert_url("{blender_version}-release-OSX_10.5_i386.zip")
             else:
                 assert_url("{blender_version}-release-OSX_10.5_x86_64.zip")
-        elif blender_Version < Version("2.65"):
+        elif blender_Version < BlenderVersion("2.65"):
             if bits == 32:
                 assert_url("{blender_version}-release-OSX_10.6_i386.zip")
             else:
                 assert_url("{blender_version}-release-OSX_10.6_x86_64.zip")
 
-        elif blender_Version < Version("2.71"):
+        elif blender_Version < BlenderVersion("2.71"):
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.6-i386.zip")
             else:
                 assert_url("{blender_version}-OSX_10.6-x86_64.zip")
-        elif blender_Version < Version("2.79"):
+        elif blender_Version < BlenderVersion("2.79"):
             assert_url("{blender_version}-OSX_10.6-x86_64.zip")
-        else:  # Version("2.71") < blender_Version < Version("2.79")
+        else:  # BlenderVersion("2.71") < blender_Version < BlenderVersion("2.79")
             if bits == 32:
                 assert_url("{blender_version}-OSX_10.6-i386.zip")
             else:
                 assert_url("{blender_version}-OSX_10.6-x86_64.zip")
     elif operative_system == "windows":
-        if blender_Version >= Version("2.93"):
+        if blender_Version >= BlenderVersion("2.93"):
             assert_url("{blender_version}-windows-x64.zip")
-        elif blender_Version >= Version("2.83.14") and blender_Version < Version(
-            "2.84"
-        ):
+        elif blender_Version >= BlenderVersion(
+            "2.83.14"
+        ) and blender_Version < BlenderVersion("2.84"):
             assert_url("{blender_version}-windows-x64.zip")
-        elif blender_Version > Version("2.80"):
+        elif blender_Version > BlenderVersion("2.80"):
             assert_url("{blender_version}-windows64.zip")
-        elif blender_Version > Version("2.65"):
+        elif blender_Version > BlenderVersion("2.65"):
             assert_url("{blender_version}-windows{bits}.zip")
-        elif blender_Version > Version("2.60"):
+        elif blender_Version > BlenderVersion("2.60"):
             assert_url("{blender_version}-release-windows{bits}.zip")
-        else:  # blender_Version < Version("2.61")
+        else:  # blender_Version < BlenderVersion("2.61")
             assert_url("{blender_version}-windows{bits}.zip")
     else:  # operative_system == "linux":
-        if blender_Version >= Version("2.93"):
+        if blender_Version >= BlenderVersion("2.93"):
             assert_url("{blender_version}-linux-x64.tar.xz")
-        elif blender_Version >= Version("2.83.14") and blender_Version < Version(
-            "2.84"
-        ):
+        elif blender_Version >= BlenderVersion(
+            "2.83.14"
+        ) and blender_Version < BlenderVersion("2.84"):
             assert_url("{blender_version}-linux-x64.tar.xz")
-        elif blender_Version > Version("2.81"):
+        elif blender_Version > BlenderVersion("2.81"):
             assert_url("{blender_version}-linux64.tar.xz")
-        elif blender_Version == Version("2.81"):
+        elif blender_Version == BlenderVersion("2.81"):
             assert_url("{blender_version}-linux-glibc217-x86_64.tar.bz2")
-        elif blender_Version == Version("2.80"):
+        elif blender_Version == BlenderVersion("2.80"):
             if bits == 32:
                 assert_url("{blender_version}-linux-glibc224-i686.tar.bz2")
             else:
                 assert_url("{blender_version}-linux-glibc217-x86_64.tar.bz2")
-        elif blender_Version == Version("2.79"):
+        elif blender_Version == BlenderVersion("2.79"):
             if bits == 32:
                 assert_url("{blender_version}-linux-glibc219-i686.tar.bz2")
             else:
                 assert_url("{blender_version}-linux-glibc219-x86_64.tar.bz2")
-        elif blender_Version < Version("2.65"):
+        elif blender_Version < BlenderVersion("2.65"):
             if bits == 32:
                 assert_url("{blender_version}-linux-glibc27-i686.tar.bz2")
             else:
                 assert_url("{blender_version}-linux-glibc27-x86_64.tar.bz2")
-        else:  # Version("2.64") < blender_Version < Version("2.79")
+        else:  # BlenderVersion("2.64") < blender_Version < BlenderVersion("2.79")
             if bits == 32:
                 assert_url("{blender_version}-linux-glibc211-i686.tar.bz2")
             else:

--- a/tests/test_list_available_blender_versions.py
+++ b/tests/test_list_available_blender_versions.py
@@ -9,36 +9,9 @@ import pytest
 
 from blender_downloader import (
     MINIMUM_VERSION_SUPPPORTED,
+    BlenderVersion,
     list_available_blender_versions,
 )
-
-
-class BlenderVersion:
-    """Lazy comparison of Blender versions."""
-
-    def __init__(self, raw):
-        self.raw = raw
-
-        self.version_info = []
-        for i, partial in enumerate(raw.split(".")):
-            if i > 1:
-                for ch in partial:
-                    if ch.isalpha():
-                        break
-                    self.version_info.append(int(ch))
-            else:
-                num = ""
-                for ch in partial:
-                    if ch.isalpha():
-                        break
-                    num += ch
-                self.version_info.append(int(num))
-
-    def __lt__(self, other):
-        return other.version_info >= self.version_info
-
-    def __repr__(self):
-        return self.raw
 
 
 @pytest.mark.parametrize("maximum_versions", (1, 2, random.randint(5, 10), math.inf))
@@ -63,8 +36,8 @@ def test_list_available_blender_versions(
 
     for raw_version in stdout_lines:
         version = BlenderVersion(raw_version)
-        assert min_version_supported < version
+        assert min_version_supported <= version
 
         if prev_version is not None:
-            assert version < prev_version
+            assert prev_version > version
         prev_version = version


### PR DESCRIPTION
Additionally:

- Don't depend on setuptools' `pkg_resources`.